### PR TITLE
Downgrade dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,8 +26,8 @@ Test / fork := true
 libraryDependencies ++= Seq(
   "org.mockito" %% "mockito-scala-scalatest" % "1.16.37" % Test,
   "org.scalatest" %% "scalatest" % "3.2.9" % Test,
-  "org.scala-lang.modules" %% "scala-xml" % "1.1.2",
-  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.2.0",
+  "org.scala-lang.modules" %% "scala-xml" % "1.2.0",
+  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2",
 )
 
 resolvers += "Artifactory" at "https://flow.jfrog.io/flow/libs-release/"

--- a/build.sbt
+++ b/build.sbt
@@ -26,8 +26,8 @@ Test / fork := true
 libraryDependencies ++= Seq(
   "org.mockito" %% "mockito-scala-scalatest" % "1.16.37" % Test,
   "org.scalatest" %% "scalatest" % "3.2.9" % Test,
-  "org.scala-lang.modules" %% "scala-xml" % "2.0.0",
-  "org.scala-lang.modules" %% "scala-parser-combinators" % "2.0.0",
+  "org.scala-lang.modules" %% "scala-xml" % "1.1.2",
+  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.2.0",
 )
 
 resolvers += "Artifactory" at "https://flow.jfrog.io/flow/libs-release/"


### PR DESCRIPTION
Downgrade `scala-xml` and `scala-parser-combinators` to compatible version.
This lib is used in https://dependency.flow.io/libraries/lib-da1850f9b33a43bd9167b9304061cf4e