### PR TITLE
LOG-3597: expose the ProcessBuilder so we can run the process asynchronously

### DIFF
--- a/src/test/scala/io/flow/spdf/PdfSpec.scala
+++ b/src/test/scala/io/flow/spdf/PdfSpec.scala
@@ -1,10 +1,13 @@
 package io.flow.spdf
 
-import java.io.File
-
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import java.io.File
+import java.util.concurrent.TimeUnit
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future, TimeoutException, blocking}
 import scala.sys.process._
 
 class PdfSpec extends AnyWordSpec with Matchers {
@@ -25,15 +28,14 @@ class PdfSpec extends AnyWordSpec with Matchers {
 
     }
 
+    val page =
+      """
+        |<html><body><h1>Hello</h1></body></html>
+            """.stripMargin
+
     PdfConfig.findExecutable match {
       case Some(_) =>
         "generate a PDF file from an HTML string" in {
-
-          val page =
-            """
-              |<html><body><h1>Hello</h1></body></html>
-            """.stripMargin
-
           val file = File.createTempFile("scala.spdf", "pdf")
 
           val pdf = Pdf(PdfConfig.default)
@@ -41,6 +43,34 @@ class PdfSpec extends AnyWordSpec with Matchers {
           pdf.run(page, file)
 
           Seq("file", file.getAbsolutePath).!! should include("PDF document")
+        }
+
+        "generate a PDF file from an HTML string with timeout" in {
+          val file = File.createTempFile("scala.spdf", "pdf")
+
+          val pdf = Pdf(PdfConfig.default)
+
+          val p = pdf.prepare(page, file).run() // start asynchronously
+          val f = Future(blocking(p.exitValue())) // wrap in Future
+          try Await.result(f, Duration(5, TimeUnit.SECONDS)) catch {
+            case _: TimeoutException => p.destroy()
+          }
+
+          Seq("file", file.getAbsolutePath).!! should include("PDF document")
+        }
+
+        "destroy process on timeout" in {
+          val file = File.createTempFile("scala.spdf", "pdf")
+
+          val pdf = Pdf(PdfConfig.default)
+
+          val p = pdf.prepare(page, file).run() // start asynchronously
+          val f = Future(blocking(p.exitValue())) // wrap in Future
+          try Await.result(f, Duration(50, TimeUnit.MILLISECONDS)) catch {
+            case _: TimeoutException => p.destroy()
+          }
+
+          Seq("file", file.getAbsolutePath).!! should not include "PDF document"
         }
 
       case None =>


### PR DESCRIPTION
This PR adds a new method to `Pdf` class, `prepare()`. This is similar to the previously `run()` method, but exposes the underlying `ProcessBuilder`, allowing more control under the process to generate a PDF.

For example, with this is now safe to run this in a `Future` with a timeout. If the timeout expires you can call `destroy()` to ensure that the process is finalised.