### PR TITLE
FDN-3894 Add github actions to assist scala-steward

### DIFF
--- a/.github/workflows/add-labels.yml
+++ b/.github/workflows/add-labels.yml
@@ -1,0 +1,41 @@
+name: "Add labels"
+
+on:
+  pull_request:
+    types: [opened, labeled, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  add-labels:
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'scala-steward') }}
+    steps:
+      - name: Add auto-merge label
+        if: ${{ contains(github.event.pull_request.title, 'Flow dependency updates') }}
+        run: |
+          REPO="${{ github.repository }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          LABEL_NAME="auto-merge"
+          LABEL_COLOR="2ECC71"
+          
+          # create the label if it doesn't exist
+          if ! gh label list --repo "$REPO" --limit 25 --json name --jq '.[].name' | grep -qi "^$LABEL_NAME$"; then
+            echo "Creating label '$LABEL_NAME'"
+            gh label create "$LABEL_NAME" --color "$LABEL_COLOR" --repo "$REPO"
+          fi
+          
+          # get current labels on the PR
+          LABELS=$(gh pr view "$PR_URL" --json labels --jq '.labels[].name')
+          
+          # add label if missing
+          if ! echo "$LABELS" | grep -qi "^$LABEL_NAME$"; then
+            echo "Adding '$LABEL_NAME' label to PR"
+            gh pr edit "$PR_URL" --add-label "$LABEL_NAME"
+          else
+            echo "'$LABEL_NAME' label already present"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,56 @@
+name: auto-merge
+
+on:
+  status:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  approve-and-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.state == 'success' }}
+    steps:
+      - name: log jenkins context
+        run: |
+          echo "Context is: ${{ github.event.context }}"
+
+      - name: find pull request for this commit
+        id: find_pr
+        run: |
+          REPO="${{ github.repository }}"
+          SHA="${{ github.event.sha }}"
+          
+          # find the PR associated with this commit
+          PR_JSON=$(gh pr list --repo "$REPO" --state open --json number,headRefName,labels,headRefOid)
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r --arg sha "$SHA" '.[] | select(.headRefOid == $sha) | .number')
+          
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open PR found for commit $SHA, exiting.."
+            exit 0
+          fi
+          
+          # check for auto-merge label
+          HAS_LABEL=$(echo "$PR_JSON" | jq -r --arg sha "$SHA" '.[] | select(.headRefOid == $sha) | .labels[].name' | grep -i '^auto-merge$' || true)
+          
+          if [ -z "$HAS_LABEL" ]; then
+            echo "PR #$PR_NUMBER has no 'auto-merge' label, exiting.."
+            exit 0
+          fi
+          
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: approve PR
+        if: ${{ steps.find_pr.outputs.pr_number != '' }}
+        run: gh pr review --approve "${{ steps.find_pr.outputs.pr_number }}" --repo "${{ github.repository }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: merge PR
+        if: ${{ steps.find_pr.outputs.pr_number != '' }}
+        run: gh pr merge --auto --squash "${{ steps.find_pr.outputs.pr_number }}" --repo "${{ github.repository }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-validator.yml
+++ b/.github/workflows/pr-validator.yml
@@ -1,0 +1,39 @@
+name: "PR Title and Description Check"
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  check-title-and-description:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'scala-steward') }}
+    steps:
+    - name: Check PR title and description
+      uses: actions/github-script@v4
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const payload = context.payload;
+          const prTitle = payload.pull_request.title;
+          const prDescription = payload.pull_request.body;
+
+          // The pattern for JIRA ticket format
+          const jiraPattern = /\b[A-Z]+-\d+\b|breakglass/gi;
+
+          // Check PR title
+          const hasJiraTitle = jiraPattern.test(prTitle);
+          console.log(`PR title: ${hasJiraTitle ? 'Valid' : 'Invalid'}`);
+
+          // Check PR description
+          const hasJiraDescription = prDescription ? prDescription.match(jiraPattern) : false;
+          console.log(`PR description: ${hasJiraDescription ? 'Valid' : 'Invalid'}`);
+
+          if (hasJiraTitle || hasJiraDescription) {
+            console.log('PR title or description format is correct.');
+          } else {
+            const errorMessage = [];
+            errorMessage.push('The PR title and description do not include a valid JIRA ticket!');
+            console.log(errorMessage.join('\n'));
+
+            core.setFailed(errorMessage.join('\n'));
+          }


### PR DESCRIPTION

The actions work as follows:

* Review title of PR to check for ticket - skip if PR opened by scala-steward
* Add auto-merge label iff the PR was opened by scala-steward **and** the dependencies updated are Flow only (not third party)
* Automatically merge iff the PR has the auto-merge label **and** the status of the Jenkins run is successful  

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>